### PR TITLE
Fix user invites

### DIFF
--- a/lib/tequila/accounts/user.ex
+++ b/lib/tequila/accounts/user.ex
@@ -16,7 +16,6 @@ defmodule Tequila.Accounts.User do
     user
     |> cast(attrs, [:email])
     |> validate_required([:email])
-
-    # |> validate_format(:email, ~r/@/)
+    |> validate_format(:email, ~r/@/)
   end
 end

--- a/lib/tequila/invites.ex
+++ b/lib/tequila/invites.ex
@@ -44,10 +44,13 @@ defmodule Tequila.Invites do
   end
 
   def find_for_redeem(id) do
-    Repo.one(
+    query =
       from i in Invite,
         where: i.id == ^id and i.inserted_at < datetime_add(i.inserted_at, 5, "day")
-    )
+
+    query
+    |> Repo.one()
+    |> Repo.preload(:owner)
   end
 
   def change_redeem(%Redeem{} = redeem) do

--- a/lib/tequila_web/controllers/channel_controller.ex
+++ b/lib/tequila_web/controllers/channel_controller.ex
@@ -6,8 +6,13 @@ defmodule TequilaWeb.ChannelController do
   alias Tequila.Index
 
   def index(conn, _params) do
-    default_channel = Channels.get_default_for_user(conn.assigns[:current_user])
-    redirect(conn, to: Routes.channel_path(conn, :show, default_channel))
+    case Channels.get_default_for_user(conn.assigns[:current_user]) do
+      nil ->
+        redirect(conn, to: Routes.channel_path(conn, :new))
+
+      default_channel ->
+        redirect(conn, to: Routes.channel_path(conn, :show, default_channel))
+    end
   end
 
   def new(conn, _params) do

--- a/test/ptolemy/accounts/accounts_test.exs
+++ b/test/ptolemy/accounts/accounts_test.exs
@@ -6,8 +6,8 @@ defmodule Tequila.AccountsTest do
   describe "users" do
     alias Tequila.Accounts.User
 
-    @valid_attrs %{email: "some email"}
-    @update_attrs %{email: "some updated email"}
+    @valid_attrs %{email: "louis@example.com"}
+    @update_attrs %{email: "walouis@example.com"}
     @invalid_attrs %{email: nil}
 
     def user_fixture(attrs \\ %{}) do
@@ -31,7 +31,7 @@ defmodule Tequila.AccountsTest do
 
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Accounts.create_user(@valid_attrs)
-      assert user.email == "some email"
+      assert user.email == "louis@example.com"
     end
 
     test "create_user/1 with invalid data returns error changeset" do
@@ -41,7 +41,7 @@ defmodule Tequila.AccountsTest do
     test "update_user/2 with valid data updates the user" do
       user = user_fixture()
       assert {:ok, %User{} = user} = Accounts.update_user(user, @update_attrs)
-      assert user.email == "some updated email"
+      assert user.email == "walouis@example.com"
     end
 
     test "update_user/2 with invalid data returns error changeset" do

--- a/test/ptolemy/channels/channels_test.exs
+++ b/test/ptolemy/channels/channels_test.exs
@@ -13,7 +13,7 @@ defmodule Tequila.ChannelsTest do
     def owner_fixture() do
       alias Tequila.Accounts
 
-      email = "louis@person.guru"
+      email = "louis@example.com"
 
       try do
         Accounts.get_user_by_email!(email)

--- a/test/ptolemy/index/index_test.exs
+++ b/test/ptolemy/index/index_test.exs
@@ -13,7 +13,7 @@ defmodule Tequila.IndexTest do
     def owner_fixture() do
       alias Tequila.Accounts
 
-      email = "louis@person.guru"
+      email = "louis@example.com"
 
       try do
         Accounts.get_user_by_email!(email)

--- a/test/ptolemy_web/controllers/channel_controller_test.exs
+++ b/test/ptolemy_web/controllers/channel_controller_test.exs
@@ -22,7 +22,7 @@ defmodule TequilaWeb.ChannelControllerTest do
   end
 
   def fixture_owner() do
-    email = "louis@person.guru"
+    email = "louis@example.com"
 
     try do
       Accounts.get_user_by_email!(email)
@@ -40,7 +40,7 @@ defmodule TequilaWeb.ChannelControllerTest do
   end
 
   def fixture_user() do
-    email = "walouis@person.guru"
+    email = "walouis@example.com"
 
     try do
       Accounts.get_user_by_email!(email)

--- a/test/ptolemy_web/controllers/invite_controller_test.exs
+++ b/test/ptolemy_web/controllers/invite_controller_test.exs
@@ -4,7 +4,7 @@ defmodule TequilaWeb.InviteControllerTest do
   alias Tequila.Accounts
 
   def fixture_owner() do
-    email = "louis@person.guru"
+    email = "louis@example.com"
 
     try do
       Accounts.get_user_by_email!(email)

--- a/test/ptolemy_web/controllers/link_controller_test.exs
+++ b/test/ptolemy_web/controllers/link_controller_test.exs
@@ -23,7 +23,7 @@ defmodule TequilaWeb.LinkControllerTest do
   end
 
   def fixture(:owner) do
-    email = "louis@person.guru"
+    email = "louis@example.com"
 
     try do
       Accounts.get_user_by_email!(email)

--- a/test/ptolemy_web/controllers/page_controller_test.exs
+++ b/test/ptolemy_web/controllers/page_controller_test.exs
@@ -4,7 +4,7 @@ defmodule TequilaWeb.PageControllerTest do
   alias Tequila.Accounts
 
   def fixture_owner() do
-    email = "louis@person.guru"
+    email = "louis@example.com"
 
     try do
       Accounts.get_user_by_email!(email)

--- a/test/ptolemy_web/plugs/auth_plug_test.exs
+++ b/test/ptolemy_web/plugs/auth_plug_test.exs
@@ -7,7 +7,7 @@ defmodule TequilaWeb.AuthPlugTest do
   alias TequilaWeb.AuthPlug
 
   def fixture_owner() do
-    email = "louis@person.guru"
+    email = "louis@example.com"
 
     try do
       Accounts.get_user_by_email!(email)
@@ -19,12 +19,12 @@ defmodule TequilaWeb.AuthPlugTest do
   end
 
   def fixture_credential() do
-    query = from(c in Credential, where: c.provider == "email" and c.uid == "louis@person.guru")
+    query = from(c in Credential, where: c.provider == "email" and c.uid == "louis@example.com")
 
     Repo.one(query) ||
       Repo.insert!(%Credential{
         provider: "email",
-        uid: "louis@person.guru",
+        uid: "louis@example.com",
         token: "supersecretpassword",
         user_id: fixture_owner().id
       })
@@ -46,7 +46,7 @@ defmodule TequilaWeb.AuthPlugTest do
     } do
       other_user =
         Repo.insert!(%Accounts.User{
-          email: "walouis@person.guru"
+          email: "walouis@example.com"
         })
 
       session =


### PR DESCRIPTION
Invites previously couldn't be redeem because of an unloaded
relationship, preventing invitees from registering on the Tequila
instance where they've been invited. A redirect to create a new channel
has also been added in case your user has no channels.