### PR TITLE
Only quote search term if it contains whitespace

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,7 @@ config :tequila, Tequila.Repo,
   password: System.get_env("TEST_DATABASE_PASS") || "imnotmeantforproduction",
   database: System.get_env("TEST_DATABASE_NAME") || "tequila_test",
   hostname: System.get_env("TEST_DATABASE_HOST") || "localhost",
-  port: System.get_env("TEST_DATABASE_PORT", "5432") |> Integer.parse() |> elem(0),
+  port: (System.get_env("TEST_DATABASE_PORT") || "5432") |> Integer.parse() |> elem(0),
   pool: Ecto.Adapters.SQL.Sandbox,
   migration_primary_key: [name: :id, type: :binary_id]
 

--- a/lib/tequila/index.ex
+++ b/lib/tequila/index.ex
@@ -63,7 +63,13 @@ defmodule Tequila.Index do
   defp build_constraints([root | []]), do: build_constraints(root)
 
   defp build_constraints({:word, word}) do
-    "\"#{word}\""
+    case String.contains?(word, ["\t", "\n", "\r", "\ "]) do
+      true ->
+        "\"#{word}\""
+
+      _ ->
+        word
+    end
   end
 
   defp build_constraints({:tag, tag}) do


### PR DESCRIPTION
This is only a partial fix to the quoting problem. A more thorough fix
will be needed to fix this problem but it will impact the query parser
as well. For now, this solution will do.